### PR TITLE
Change # of failed attempts

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -5,7 +5,7 @@
  */
 
 // Number of failed logins before reCAPTCHA is shown
-$rcmail_config['failed_attempts'] = 5;
+$rcmail_config['failed_attempts'] = 1;
 
 // Release IP after how many minutes (after last failed attempt)
 $rcmail_config['expire_time'] = 30;


### PR DESCRIPTION
Because it's so easy to pass a noCAPTCHA reCAPTCHA, set the # of failed attempts to 1 so you get a reCAPTCHA if you fail.
