### PR TITLE
Fix missing Break Statement

### DIFF
--- a/rcguard.php
+++ b/rcguard.php
@@ -251,6 +251,7 @@ class rcguard extends rcube_plugin
         case 'pgsql':
         case 'postgres':
             $ts = "EXTRACT (EPOCH FROM $field)";
+            break;
         default:
             $ts = "UNIX_TIMESTAMP($field)";
         }


### PR DESCRIPTION
Postgresql is not too happy.

```
ERROR:  function unix_timestamp(timestamp with time zone) does not exist at character 8 
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
STATEMENT:  SELECT UNIX_TIMESTAMP(last) AS last, UNIX_TIMESTAMP(NOW()) as time  FROM rcguard WHERE ip = '192.168.202.31' AND hits >= '3'    
```
