### PR TITLE
Update Postgresql

### DIFF
--- a/SQL/postgres.initial.sql
+++ b/SQL/postgres.initial.sql
@@ -1,11 +1,15 @@
 -- PostgreSQL table for rcguard
+-- edit table and indexes so the prefix is added to it if you have done so in Roundcube
 
 CREATE TABLE rcguard (
-	ip varchar(40) NOT NULL PRIMARY KEY,
-	first timestamp with time zone NOT NULL,
-	last timestamp with time zone NOT NULL,
-	hits integer NOT NULL
+    ip character varying(40) NOT NULL,
+    first timestamp with time zone NOT NULL,
+    last timestamp with time zone NOT NULL,
+    hits integer NOT NULL
 );
+
+ALTER TABLE ONLY rcguard
+    ADD CONSTRAINT rcguard_pkey PRIMARY KEY (ip);
 
 CREATE INDEX rcguard_last_idx ON rcguard(last);
 CREATE INDEX rcguard_hits_idx ON rcguard(hits);


### PR DESCRIPTION
New postgres version does not have varchar(40) but requires character varying(40)

Updated the complete file for the export of the postgresql Structure only,

Added line to explain that prefix needs to be added if it is configured so in Roundcube
